### PR TITLE
🔥 remove ap slack channel support option

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,6 @@
 ---
 blank_issues_enabled: false
 contact_links:
-  - name: "#analytical-platform-support"
-    url: https://mojdt.slack.com/archives/C4PF7QAJZ
-    about: Please ask Analytical Platform questions here
   - name: "#ask-data-platform"
     url: https://mojdt.slack.com/archives/C04VBJTKY58
     about: Please ask Data Platform questions here


### PR DESCRIPTION
This PR Removes link to Slack support, this could be confusing for a user coming from the ap support channel to then only be redirected back to that channel. thanks @tmpks